### PR TITLE
Add default BehaviorVersion

### DIFF
--- a/src/models/appstate.rs
+++ b/src/models/appstate.rs
@@ -49,6 +49,7 @@ impl ApplicationState {
             .endpoint_url(config.minio_url())
             .credentials_provider(s3creds)
             .force_path_style(true) // MinIO does not support virtual hosts
+            .behavior_version(BehaviorVersion::latest())
             .build();
 
         ApplicationState {


### PR DESCRIPTION
Docker image crashes without the `.behavior_version()`

```txt
...
backend-1         | The application panicked (crashed).
backend-1         | Message:  Invalid client configuration: A behavior major version must be set when sending a request or constructing a client. You must set it during client construction or by enabling the `behavior-version-latest` cargo feature.
backend-1         | Location: /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/aws-sdk-s3-1.31.0/src/config.rs:1390
backend-1         | 
backend-1         | Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
backend-1         | Run with RUST_BACKTRACE=full to include source snippets.
```

---

> Yes, there is only one behavior version available, yet without that, it's not going to work